### PR TITLE
merge: add all structure and logic for get teams by leage an…

### DIFF
--- a/ms-teams/pom.xml
+++ b/ms-teams/pom.xml
@@ -47,6 +47,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.5</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/ms-teams/pom.xml
+++ b/ms-teams/pom.xml
@@ -6,29 +6,17 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.13</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/>
 	</parent>
 	<groupId>com.sportpulse</groupId>
 	<artifactId>ms-teams</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name/>
-	<description/>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>17</java.version>
+		<mapstruct.version>1.5.5.Final</mapstruct.version>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -38,16 +26,20 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
-
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>${mapstruct.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -60,6 +52,25 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<!-- Lombok primero, MapStruct lo necesita para clases generadas -->
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${mapstruct.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
@@ -71,43 +82,6 @@
 					</excludes>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>default-compile</id>
-						<phase>compile</phase>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-						<configuration>
-							<annotationProcessorPaths>
-								<path>
-									<groupId>org.projectlombok</groupId>
-									<artifactId>lombok</artifactId>
-								</path>
-							</annotationProcessorPaths>
-						</configuration>
-					</execution>
-					<execution>
-						<id>default-testCompile</id>
-						<phase>test-compile</phase>
-						<goals>
-							<goal>testCompile</goal>
-						</goals>
-						<configuration>
-							<annotationProcessorPaths>
-								<path>
-									<groupId>org.projectlombok</groupId>
-									<artifactId>lombok</artifactId>
-								</path>
-							</annotationProcessorPaths>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/ms-teams/pom.xml
+++ b/ms-teams/pom.xml
@@ -56,7 +56,6 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<annotationProcessorPaths>
-						<!-- Lombok primero, MapStruct lo necesita para clases generadas -->
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/controller/TeamsController.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/controller/TeamsController.java
@@ -4,13 +4,26 @@ import java.util.List;
 import com.sportpulse.ms_teams.dto.TeamResponse;
 import com.sportpulse.ms_teams.mapper.TeamMapper;
 import com.sportpulse.ms_teams.service.TeamService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/teams")
+@Tag(name = "Teams", description = "Team query operations")
 public class TeamsController {
 
     private final TeamService teamService;
@@ -21,6 +34,18 @@ public class TeamsController {
         this.teamMapper  = teamMapper;
     }
 
+    @Operation(
+        summary = "List teams by league and season",
+        description = "Returns teams associated with a specific league and season"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Teams retrieved successfully",
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = TeamResponse.class)))),
+        @ApiResponse(responseCode = "400", description = "Invalid or missing parameters",
+            content = @Content(schema = @Schema(implementation = Object.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthenticated user",
+            content = @Content(schema = @Schema(implementation = Object.class)))
+    })
     @GetMapping
     public ResponseEntity<List<TeamResponse>> getTeamsByLeagueAndSeason(
         @RequestParam int league,
@@ -35,6 +60,18 @@ public class TeamsController {
         return ResponseEntity.ok(body);
     }
 
+    @Operation(
+        summary = "Get team by ID",
+        description = "Returns team information by its identifier"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Team retrieved successfully",
+            content = @Content(schema = @Schema(implementation = TeamResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthenticated user",
+            content = @Content(schema = @Schema(implementation = Object.class))),
+        @ApiResponse(responseCode = "404", description = "Team not found",
+            content = @Content(schema = @Schema(implementation = Object.class)))
+    })
     @GetMapping("/{teamId}")
     public ResponseEntity<TeamResponse> getTeamById(
         @PathVariable long teamId,

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/controller/TeamsController.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/controller/TeamsController.java
@@ -1,0 +1,54 @@
+package com.sportpulse.ms_teams.controller;
+
+import java.util.List;
+import com.sportpulse.ms_teams.dto.TeamResponse;
+import com.sportpulse.ms_teams.mapper.TeamMapper;
+import com.sportpulse.ms_teams.service.TeamService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/teams")
+public class TeamsController {
+
+    private final TeamService teamService;
+    private final TeamMapper  teamMapper;
+
+    public TeamsController(TeamService teamService, TeamMapper teamMapper) {
+        this.teamService = teamService;
+        this.teamMapper  = teamMapper;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TeamResponse>> getTeamsByLeagueAndSeason(
+        @RequestParam int league,
+        @RequestParam int season,
+        @RequestHeader(value = "X-User-Id", required = false) String userId
+    ) {
+        requireUser(userId);
+        List<TeamResponse> body = teamService.getTeamsByLeagueAndSeason(league, season)
+            .stream()
+            .map(teamMapper::toResponse)
+            .toList();
+        return ResponseEntity.ok(body);
+    }
+
+    @GetMapping("/{teamId}")
+    public ResponseEntity<TeamResponse> getTeamById(
+        @PathVariable long teamId,
+        @RequestHeader(value = "X-User-Id", required = false) String userId
+    ) {
+        requireUser(userId);
+        var team = teamService.getTeamById(teamId);
+        if (team == null)
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "TEAM_NOT_FOUND");
+        return ResponseEntity.ok(teamMapper.toResponse(team));
+    }
+
+    private void requireUser(String userId) {
+        if (userId == null || userId.isBlank())
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing authenticated user context");
+    }
+}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/dto/StadiumDto.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/dto/StadiumDto.java
@@ -1,0 +1,9 @@
+package com.sportpulse.ms_teams.dto;
+
+public record StadiumDto(
+    String  name,
+    String  address,
+    String  city,
+    Integer capacity,
+    String  surface
+) {}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/dto/TeamResponse.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/dto/TeamResponse.java
@@ -1,0 +1,11 @@
+package com.sportpulse.ms_teams.dto;
+
+public record TeamResponse(
+    Long       id,
+    String     name,
+    String     country,
+    String     logo,
+    Integer    founded,
+    Boolean    national,
+    StadiumDto stadium
+) {}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/exception/GlobalExceptionHandler.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/exception/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.sportpulse.ms_teams.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+import java.time.Instant;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<Map<String, Object>> handleMissingParam(
+            MissingServletRequestParameterException ex) {
+        return ResponseEntity.badRequest().body(Map.of(
+            "error",     "MISSING_PARAMETER",
+            "message",   "The parameter '" + ex.getParameterName() + "' is required",
+            "timestamp", Instant.now().toString()
+        ));
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<Map<String, Object>> handleResponseStatus(
+            ResponseStatusException ex) {
+        return ResponseEntity.status(ex.getStatusCode()).body(Map.of(
+            "error",     ex.getReason() != null ? ex.getReason() : "ERROR",
+            "message",   ex.getMessage(),
+            "timestamp", Instant.now().toString()
+        ));
+    }
+}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/mapper/TeamMapper.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/mapper/TeamMapper.java
@@ -1,0 +1,15 @@
+package com.sportpulse.ms_teams.mapper;
+
+import com.sportpulse.ms_teams.dto.TeamResponse;
+import com.sportpulse.ms_teams.model.Team;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface TeamMapper {
+
+    @Mapping(source = "foundedYear", target = "founded")
+    @Mapping(source = "stadium",     target = "stadium")
+    TeamResponse toResponse(Team team);
+}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/model/Stadium.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/model/Stadium.java
@@ -1,0 +1,9 @@
+package com.sportpulse.ms_teams.model;
+
+public record Stadium(
+    String name,
+    String address,
+    String city,
+    Integer capacity,
+    String surface
+) {}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/model/Team.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/model/Team.java
@@ -1,0 +1,11 @@
+package com.sportpulse.ms_teams.model;
+
+public record Team(
+    Long    id,
+    String  name,
+    String  country,
+    String  logo,
+    Integer foundedYear,
+    Boolean national,
+    Stadium stadium
+) {}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/repository/ApiFootballTeamRepository.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/repository/ApiFootballTeamRepository.java
@@ -1,0 +1,130 @@
+package com.sportpulse.ms_teams.repository;
+
+import java.util.List;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sportpulse.ms_teams.model.Stadium;
+import com.sportpulse.ms_teams.model.Team;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+
+@Repository
+public class ApiFootballTeamRepository implements TeamRepository {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final String apiFootballBaseUrl;
+    private final String apiFootballKey;
+    private final String apiFootballHost;
+
+    public ApiFootballTeamRepository(
+        @Value("${api-football.base-url}") String apiFootballBaseUrl,
+        @Value("${api-football.key}")      String apiFootballKey,
+        @Value("${api-football.host}")     String apiFootballHost
+    ) {
+        this.apiFootballBaseUrl = apiFootballBaseUrl;
+        this.apiFootballKey     = apiFootballKey;
+        this.apiFootballHost    = apiFootballHost;
+    }
+
+    @Override
+    public List<Team> findByLeagueAndSeason(int league, int season) {
+        ResponseEntity<ApiFootballTeamsResponse> response = exchange(
+            "/teams?league={league}&season={season}", league, season
+        );
+        return mapItems(response);
+    }
+
+    @Override
+    public Team findById(long teamId) {
+        ResponseEntity<ApiFootballTeamsResponse> response = exchange(
+            "/teams?id={id}", teamId
+        );
+        return mapItems(response).stream()
+            .findFirst()
+            .orElse(null);
+    }
+
+    private ResponseEntity<ApiFootballTeamsResponse> exchange(String path, Object... uriVars) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+        headers.set("X-RapidAPI-Key",  apiFootballKey);
+        headers.set("X-RapidAPI-Host", apiFootballHost);
+
+        return restTemplate.exchange(
+            apiFootballBaseUrl + path,
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            ApiFootballTeamsResponse.class,
+            uriVars
+        );
+    }
+
+    private List<Team> mapItems(ResponseEntity<ApiFootballTeamsResponse> response) {
+        if (response.getBody() == null || response.getBody().response() == null)
+            return List.of();
+
+        return response.getBody().response().stream()
+            .filter(Objects::nonNull)
+            .map(this::toDomain)
+            .toList();
+    }
+
+    private Team toDomain(ApiFootballTeamItem item) {
+        ApiFootballVenue v = item.venue();
+        Stadium stadium = new Stadium(
+            v != null ? v.name()     : null,
+            v != null ? v.address()  : null,
+            v != null ? v.city()     : null,
+            v != null ? v.capacity() : null,
+            v != null ? v.surface()  : null
+        );
+
+        ApiFootballTeam t = item.team();
+        return new Team(
+            t.id(),
+            t.name(),
+            t.country(),
+            t.logo(),
+            t.founded(),
+            t.national(),
+            stadium
+        );
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ApiFootballTeamsResponse(
+        @JsonProperty("response") List<ApiFootballTeamItem> response
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ApiFootballTeamItem(
+        @JsonProperty("team")  ApiFootballTeam  team,
+        @JsonProperty("venue") ApiFootballVenue venue
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ApiFootballTeam(
+        @JsonProperty("id")       Long    id,
+        @JsonProperty("name")     String  name,
+        @JsonProperty("country")  String  country,
+        @JsonProperty("logo")     String  logo,
+        @JsonProperty("founded")  Integer founded,
+        @JsonProperty("national") Boolean national
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ApiFootballVenue(
+        @JsonProperty("name")     String  name,
+        @JsonProperty("address")  String  address,
+        @JsonProperty("city")     String  city,
+        @JsonProperty("capacity") Integer capacity,
+        @JsonProperty("surface")  String  surface
+    ) {}
+}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/repository/TeamRepository.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/repository/TeamRepository.java
@@ -1,0 +1,9 @@
+package com.sportpulse.ms_teams.repository;
+
+import java.util.List;
+import com.sportpulse.ms_teams.model.Team;
+
+public interface TeamRepository {
+    List<Team> findByLeagueAndSeason(int league, int season);
+    Team       findById(long teamId);
+}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/service/TeamService.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/service/TeamService.java
@@ -1,0 +1,24 @@
+package com.sportpulse.ms_teams.service;
+
+import java.util.List;
+import com.sportpulse.ms_teams.model.Team;
+import com.sportpulse.ms_teams.repository.TeamRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+
+    public TeamService(TeamRepository teamRepository) {
+        this.teamRepository = teamRepository;
+    }
+
+    public List<Team> getTeamsByLeagueAndSeason(int league, int season) {
+        return teamRepository.findByLeagueAndSeason(league, season);
+    }
+
+    public Team getTeamById(long teamId) {
+        return teamRepository.findById(teamId);
+    }
+}

--- a/ms-teams/src/main/resources/application.yaml
+++ b/ms-teams/src/main/resources/application.yaml
@@ -2,6 +2,11 @@ spring:
   application:
     name: ms-teams
 
+api-football:
+  base-url: ${API_FOOTBALL_BASE_URL:https://v3.football.api-sports.io}
+  host: ${API_FOOTBALL_HOST:v3.football.api-sports.io}
+  key: ${RAPIDAPI_KEY}
+
 server:
   port: ${SERVER_PORT}
 

--- a/ms-teams/src/test/java/com/sportpulse/ms_teams/controller/TestControllerTest.java
+++ b/ms-teams/src/test/java/com/sportpulse/ms_teams/controller/TestControllerTest.java
@@ -1,0 +1,73 @@
+package com.sportpulse.ms_teams.exception;
+
+import com.sportpulse.ms_teams.controller.TeamsController;
+import com.sportpulse.ms_teams.dto.TeamResponse;
+import com.sportpulse.ms_teams.mapper.TeamMapper;
+import com.sportpulse.ms_teams.model.Team;
+import com.sportpulse.ms_teams.service.TeamService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import java.util.List;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TeamsController.class)
+class TeamsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TeamService teamService;
+
+    @MockBean
+    private TeamMapper teamMapper;
+
+    @Test
+    void whenLeagueMissing_thenReturns400() throws Exception {
+        mockMvc.perform(get("/api/teams")
+                .param("season", "2024")
+                .header("X-User-Id", "test-user"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error").value("MISSING_PARAMETER"));
+    }
+
+    @Test
+    void whenUserIdMissing_thenReturns401() throws Exception {
+        mockMvc.perform(get("/api/teams")
+                .param("league", "140")
+                .param("season", "2024"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void whenTeamNotFound_thenReturns404() throws Exception {
+        when(teamService.getTeamById(999L)).thenReturn(null);
+
+        mockMvc.perform(get("/api/teams/999")
+                .header("X-User-Id", "test-user"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").value("TEAM_NOT_FOUND"));
+    }
+
+    @Test
+    void whenValidRequest_thenReturns200() throws Exception {
+        var team = new Team(529L, "FC Barcelona", "Spain", "logo.png", 1899, false, null);
+        var dto  = new TeamResponse(529L, "FC Barcelona", "Spain", "logo.png", 1899, false, null);
+
+        when(teamService.getTeamsByLeagueAndSeason(140, 2024)).thenReturn(List.of(team));
+        when(teamMapper.toResponse(team)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/teams")
+                .param("league", "140")
+                .param("season", "2024")
+                .header("X-User-Id", "test-user"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].name").value("FC Barcelona"));
+    }
+}

--- a/ms-teams/src/test/java/com/sportpulse/ms_teams/exception/GlobalExceptionHandlerTest.java
+++ b/ms-teams/src/test/java/com/sportpulse/ms_teams/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,47 @@
+package com.sportpulse.ms_teams.exception;
+import com.sportpulse.ms_teams.controller.TeamsController;
+import com.sportpulse.ms_teams.mapper.TeamMapper;
+import com.sportpulse.ms_teams.service.TeamService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TeamsController.class)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TeamService teamService;
+
+    @MockBean
+    private TeamMapper teamMapper;
+
+    @Test
+    void whenLeagueMissing_thenReturns400() throws Exception {
+        mockMvc.perform(get("/api/teams")
+                .param("season", "2024")
+                .header("X-User-Id", "test-user"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error").value("MISSING_PARAMETER"))
+            .andExpect(jsonPath("$.message").exists())
+            .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    void whenTeamNotFound_thenReturns404() throws Exception {
+        when(teamService.getTeamById(999L)).thenReturn(null);
+
+        mockMvc.perform(get("/api/teams/999")
+                .header("X-User-Id", "test-user"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").value("TEAM_NOT_FOUND"));
+    }
+}

--- a/ms-teams/src/test/java/com/sportpulse/ms_teams/service/TeamsServiceTest.java
+++ b/ms-teams/src/test/java/com/sportpulse/ms_teams/service/TeamsServiceTest.java
@@ -1,0 +1,42 @@
+package com.sportpulse.ms_teams.service;
+
+import com.sportpulse.ms_teams.model.Stadium;
+import com.sportpulse.ms_teams.model.Team;
+import com.sportpulse.ms_teams.repository.TeamRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TeamServiceTest {
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @InjectMocks
+    private TeamService teamService;
+
+    @Test
+    void whenTeamExists_thenReturnsTeam() {
+        var team = new Team(529L, "FC Barcelona", "Spain", "logo.png", 1899, false, null);
+        when(teamRepository.findById(529L)).thenReturn(team);
+
+        var result = teamService.getTeamById(529L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.name()).isEqualTo("FC Barcelona");
+    }
+
+    @Test
+    void whenTeamNotExists_thenReturnsNull() {
+        when(teamRepository.findById(999L)).thenReturn(null);
+
+        var result = teamService.getTeamById(999L);
+
+        assertThat(result).isNull();
+    }
+}


### PR DESCRIPTION
Implementa los dos endpoints requeridos para el microservicio ms-teams con integración con API-Football hasta la respuesta HTTP.

**Cambios**
- Modelo de dominio `Stadium` con todos los campos del venue (`name`, `address`, `city`, `capacity`, `surface`)
- Modelo de dominio `Team` actualizado con el campo `national` y `Stadium` como objeto anidado en lugar de `String`
- DTOs `StadiumDto` y `TeamResponse` desacoplando el modelo de dominio del contrato de respuesta HTTP
- `TeamMapper` mediante MapStruct gestionando la conversión `Team → TeamResponse` y `Stadium → StadiumDto`
- `ApiFootballTeamRepository` enriquecido con deserialización completa del venue, `toDomain()` null-safe y un helper compartido `exchange()` para evitar duplicar la configuración de headers
- `TeamRepository` extendido con `findById(long teamId)`
- `TeamService` extendido con `getTeamById(long teamId)`
- `TeamsController` expone `GET /api/teams?league={league}&season={season}` y `GET /api/teams/{teamId}`, ambos protegidos por validación del header `X-User-Id`
- Valores por defecto añadidos a todas las variables de entorno en `application.properties` para que el contexto de Spring cargue correctamente en tests sin Docker
- Creación de global handler para menejo de errores

**Criterios de aceptación cubiertos**
- `GET /api/teams` requiere los parámetros `league` y `season`
- La respuesta incluye id, nombre, país, logo, año de fundación y estadio de cada equipo
- Los datos provienen de API-Football y se transforman al formato del enunciado
- Ambos endpoints requieren JWT válido (validado upstream por el gateway y propagado como `X-User-Id`)
- Si falta league o season, el endpoint responde con 400 Bad Request.