### PR TITLE
merge: return user data instead of accessToken on register

### DIFF
--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/common/model/dto/response/RegisterResponse.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/common/model/dto/response/RegisterResponse.java
@@ -1,0 +1,24 @@
+package com.sportpulse.ms_auth.common.model.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@Schema(description = "Response for user registration")
+public record RegisterResponse(
+        @Schema(description = "ID of the created user", example = "550e8400-e29b-41d4-a716-446655440000")
+        String id,
+
+        @Schema(description = "Username", example = "javier_ruiz")
+        String username,
+
+        @Schema(description = "Email", example = "javier@email.com")
+        String email,
+
+        @Schema(description = "User role", example = "USER")
+        String role,
+
+        @Schema(description = "Creation timestamp", example = "2025-01-15T10:30:00Z")
+        Instant createdAt
+) {
+}

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/common/model/dto/response/TokenResponse.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/common/model/dto/response/TokenResponse.java
@@ -8,6 +8,13 @@ import lombok.Builder;
 public record TokenResponse(
         @Schema(description = "Token JWT para usar en header Authorization",
                 example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-        String accessToken
+        String token,
+        @Schema(description = "Tipo de token", example = "Bearer")
+        String tokenType,
+        @Schema(description = "Tiempo de expiración del token en segundos", example = "3600")
+        long expiresIn,
+        @Schema(description = "ID del usuario autenticado",
+                example = "550e8400-e29b-41d4-a716-446655440000")
+        String userId
 ) {
 }

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/common/model/mapper/UserMapper.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/common/model/mapper/UserMapper.java
@@ -16,6 +16,9 @@ public interface UserMapper {
     @Mapping(target = "password", ignore = true)
     UserEntity toUserEntity(RegisterRequest request);
 
-    @Mapping(target = "accessToken", source = "token")
+    @Mapping(target = "token", source = "token")
+    @Mapping(target = "tokenType", constant = "Bearer")
+    @Mapping(target = "expiresIn", constant = "3600L")
+    @Mapping(target = "userId", ignore = true)
     TokenResponse toTokenResponse(String token);
 }

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/controller/AuthApi.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/controller/AuthApi.java
@@ -2,6 +2,7 @@ package com.sportpulse.ms_auth.controller;
 
 import com.sportpulse.ms_auth.common.model.dto.request.LoginRequest;
 import com.sportpulse.ms_auth.common.model.dto.request.RegisterRequest;
+import com.sportpulse.ms_auth.common.model.dto.response.RegisterResponse;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenPayload;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,18 +24,18 @@ public interface AuthApi {
 
     @Operation(
             summary = "Registrar usuario",
-            description = "Crea un nuevo usuario en el sistema y retorna un token JWT"
+            description = "Crea un nuevo usuario en el sistema y retorna sus datos"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Usuario creado exitosamente",
-                    content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+                    content = @Content(schema = @Schema(implementation = RegisterResponse.class))),
             @ApiResponse(responseCode = "400", description = "Datos inválidos o password no cumple requisitos",
                     content = @Content(schema = @Schema(implementation = Object.class))),
             @ApiResponse(responseCode = "409", description = "El email ya está registrado",
                     content = @Content(schema = @Schema(implementation = Object.class)))
     })
     @PostMapping("/register")
-    ResponseEntity<TokenResponse> createUser(@Valid @RequestBody RegisterRequest registerRequest);
+    ResponseEntity<RegisterResponse> createUser(@Valid @RequestBody RegisterRequest registerRequest);
 
     @Operation(
             summary = "Iniciar sesión",

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/controller/impl/AuthApiController.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/controller/impl/AuthApiController.java
@@ -2,6 +2,7 @@ package com.sportpulse.ms_auth.controller.impl;
 
 import com.sportpulse.ms_auth.common.model.dto.request.LoginRequest;
 import com.sportpulse.ms_auth.common.model.dto.request.RegisterRequest;
+import com.sportpulse.ms_auth.common.model.dto.response.RegisterResponse;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenPayload;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenResponse;
 import com.sportpulse.ms_auth.controller.AuthApi;
@@ -20,8 +21,8 @@ public class AuthApiController implements AuthApi {
     private final AuthService authService;
 
     @Override
-    public ResponseEntity<TokenResponse> createUser(@RequestBody @Valid RegisterRequest registerRequest) {
-        TokenResponse response = authService.createUser(registerRequest);
+    public ResponseEntity<RegisterResponse> createUser(@RequestBody @Valid RegisterRequest registerRequest) {
+        RegisterResponse response = authService.createUser(registerRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/service/AuthService.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/service/AuthService.java
@@ -2,11 +2,12 @@ package com.sportpulse.ms_auth.service;
 
 import com.sportpulse.ms_auth.common.model.dto.request.LoginRequest;
 import com.sportpulse.ms_auth.common.model.dto.request.RegisterRequest;
+import com.sportpulse.ms_auth.common.model.dto.response.RegisterResponse;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenPayload;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenResponse;
 
 public interface AuthService {
-    TokenResponse createUser (RegisterRequest registerRequest);
+    RegisterResponse createUser (RegisterRequest registerRequest);
     TokenResponse login (LoginRequest loginRequest);
     TokenPayload validateToken(String token);
 }

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/service/impl/AuthServiceImpl.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/service/impl/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package com.sportpulse.ms_auth.service.impl;
 import com.sportpulse.ms_auth.common.exception.DuplicateEmailException;
 import com.sportpulse.ms_auth.common.model.dto.request.LoginRequest;
 import com.sportpulse.ms_auth.common.model.dto.request.RegisterRequest;
+import com.sportpulse.ms_auth.common.model.dto.response.RegisterResponse;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenPayload;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenResponse;
 import com.sportpulse.ms_auth.common.model.entities.UserEntity;
@@ -34,7 +35,7 @@ public class AuthServiceImpl implements AuthService {
     private final UserMapper userMapper;
 
     @Override
-    public TokenResponse createUser(@Valid RegisterRequest registerRequest) {
+    public RegisterResponse createUser(@Valid RegisterRequest registerRequest) {
         log.info("Intentando crear usuario para email: {}", registerRequest.email());
 
         if (userEntityRepository.findByEmail(registerRequest.email()).isPresent()) {
@@ -49,11 +50,12 @@ public class AuthServiceImpl implements AuthService {
         UserEntity userCreated = userEntityRepository.save(userToSave);
         log.info("Usuario creado exitosamente con ID: {}", userCreated.getId());
 
-        return jwtService.generateToken(
-                userCreated.getEmail(),
-                userCreated.getId().toString(),
-                userCreated.getUsername(),
-                userCreated.getRole().name());
+        return new RegisterResponse(
+            userCreated.getId().toString(),
+            userCreated.getUsername(),
+            userCreated.getEmail(),
+            userCreated.getRole().name(),
+            userCreated.getCreatedAt());
     }
 
     @Override

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/service/impl/JwtServiceImpl.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/service/impl/JwtServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 @Service
 public class JwtServiceImpl implements JwtService {
@@ -50,7 +51,10 @@ public class JwtServiceImpl implements JwtService {
                 .compact();
 
         return TokenResponse.builder()
-                .accessToken(token)
+                .token(token)
+                .tokenType("Bearer")
+                .expiresIn(TimeUnit.MILLISECONDS.toSeconds(expirationTime))
+                .userId(userId)
                 .build();
     }
 

--- a/ms-auth/src/test/java/com/sportpulse/ms_auth/controller/AuthApiControllerTest.java
+++ b/ms-auth/src/test/java/com/sportpulse/ms_auth/controller/AuthApiControllerTest.java
@@ -61,12 +61,15 @@ class AuthApiControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.token").exists())
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.expiresIn").isNumber())
+                .andExpect(jsonPath("$.userId").exists())
                 .andReturn();
 
         TokenResponse response = objectMapper.readValue(
                 result.getResponse().getContentAsString(), TokenResponse.class);
-        assertNotNull(response.accessToken());
+        assertNotNull(response.token());
     }
 
     @Test
@@ -170,12 +173,15 @@ class AuthApiControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.token").exists())
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.expiresIn").isNumber())
+                .andExpect(jsonPath("$.userId").exists())
                 .andReturn();
 
         TokenResponse response = objectMapper.readValue(
                 result.getResponse().getContentAsString(), TokenResponse.class);
-        assertNotNull(response.accessToken());
+        assertNotNull(response.token());
     }
 
     @Test
@@ -240,7 +246,7 @@ class AuthApiControllerTest {
     void validate_withValidToken_returns200() throws Exception {
         RegisterRequest registerRequest = new RegisterRequest("john", "john@test.com", "Password1");
         TokenResponse tokenResponse = authService.createUser(registerRequest);
-        String token = tokenResponse.accessToken();
+        String token = tokenResponse.token();
 
         mockMvc.perform(post("/api/auth/validate")
                         .header("Authorization", "Bearer " + token))

--- a/ms-auth/src/test/java/com/sportpulse/ms_auth/controller/AuthApiControllerTest.java
+++ b/ms-auth/src/test/java/com/sportpulse/ms_auth/controller/AuthApiControllerTest.java
@@ -3,6 +3,7 @@ package com.sportpulse.ms_auth.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sportpulse.ms_auth.common.model.dto.request.LoginRequest;
 import com.sportpulse.ms_auth.common.model.dto.request.RegisterRequest;
+import com.sportpulse.ms_auth.common.model.dto.response.RegisterResponse;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenResponse;
 import com.sportpulse.ms_auth.repository.UserEntityRepository;
 import com.sportpulse.ms_auth.service.AuthService;
@@ -61,15 +62,17 @@ class AuthApiControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.token").exists())
-                .andExpect(jsonPath("$.tokenType").value("Bearer"))
-                .andExpect(jsonPath("$.expiresIn").isNumber())
-                .andExpect(jsonPath("$.userId").exists())
+            .andExpect(jsonPath("$.id").exists())
+            .andExpect(jsonPath("$.username").value("john"))
+            .andExpect(jsonPath("$.email").value("john@test.com"))
+            .andExpect(jsonPath("$.role").value("USER"))
+            .andExpect(jsonPath("$.createdAt").exists())
                 .andReturn();
 
-        TokenResponse response = objectMapper.readValue(
-                result.getResponse().getContentAsString(), TokenResponse.class);
-        assertNotNull(response.token());
+        RegisterResponse response = objectMapper.readValue(
+            result.getResponse().getContentAsString(), RegisterResponse.class);
+        assertNotNull(response.id());
+        assertTrue(response.createdAt().toString().endsWith("Z"));
     }
 
     @Test
@@ -245,7 +248,9 @@ class AuthApiControllerTest {
     @Test
     void validate_withValidToken_returns200() throws Exception {
         RegisterRequest registerRequest = new RegisterRequest("john", "john@test.com", "Password1");
-        TokenResponse tokenResponse = authService.createUser(registerRequest);
+        authService.createUser(registerRequest);
+        LoginRequest loginRequest = new LoginRequest("john@test.com", "Password1");
+        TokenResponse tokenResponse = authService.login(loginRequest);
         String token = tokenResponse.token();
 
         mockMvc.perform(post("/api/auth/validate")

--- a/ms-auth/src/test/java/com/sportpulse/ms_auth/service/AuthServiceImplTest.java
+++ b/ms-auth/src/test/java/com/sportpulse/ms_auth/service/AuthServiceImplTest.java
@@ -67,7 +67,7 @@ class AuthServiceImplTest {
                 .role(com.sportpulse.ms_auth.common.enums.UserRole.USER)
                 .createdAt(Instant.now())
                 .build();
-        TokenResponse tokenResponse = new TokenResponse("jwt-token");
+        TokenResponse tokenResponse = new TokenResponse("jwt-token", "Bearer", 3600L, userId.toString());
 
         when(userEntityRepository.findByEmail("john@test.com")).thenReturn(Optional.empty());
         when(userMapper.toUserEntity(any(RegisterRequest.class))).thenReturn(savedUser);
@@ -78,7 +78,7 @@ class AuthServiceImplTest {
         TokenResponse result = authService.createUser(request);
 
         assertNotNull(result);
-        assertEquals("jwt-token", result.accessToken());
+        assertEquals("jwt-token", result.token());
         verify(userEntityRepository).findByEmail("john@test.com");
         verify(userEntityRepository).save(any(UserEntity.class));
     }
@@ -110,7 +110,7 @@ class AuthServiceImplTest {
                 .role(com.sportpulse.ms_auth.common.enums.UserRole.USER)
                 .build();
         Authentication authentication = mock(Authentication.class);
-        TokenResponse tokenResponse = new TokenResponse("jwt-token");
+        TokenResponse tokenResponse = new TokenResponse("jwt-token", "Bearer", 3600L, userId.toString());
 
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
                 .thenReturn(authentication);
@@ -120,7 +120,7 @@ class AuthServiceImplTest {
         TokenResponse result = authService.login(request);
 
         assertNotNull(result);
-        assertEquals("jwt-token", result.accessToken());
+        assertEquals("jwt-token", result.token());
         verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
     }
 

--- a/ms-auth/src/test/java/com/sportpulse/ms_auth/service/AuthServiceImplTest.java
+++ b/ms-auth/src/test/java/com/sportpulse/ms_auth/service/AuthServiceImplTest.java
@@ -3,6 +3,7 @@ package com.sportpulse.ms_auth.service;
 import com.sportpulse.ms_auth.common.exception.DuplicateEmailException;
 import com.sportpulse.ms_auth.common.model.dto.request.LoginRequest;
 import com.sportpulse.ms_auth.common.model.dto.request.RegisterRequest;
+import com.sportpulse.ms_auth.common.model.dto.response.RegisterResponse;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenResponse;
 import com.sportpulse.ms_auth.common.model.entities.UserEntity;
 import com.sportpulse.ms_auth.common.model.mapper.UserMapper;
@@ -59,28 +60,32 @@ class AuthServiceImplTest {
     void createUser_success() {
         RegisterRequest request = new RegisterRequest("john", "john@test.com", "Password1");
         UUID userId = UUID.randomUUID();
+        Instant createdAt = Instant.now();
         UserEntity savedUser = UserEntity.builder()
                 .id(userId)
                 .username("john")
                 .email("john@test.com")
                 .password("encoded")
                 .role(com.sportpulse.ms_auth.common.enums.UserRole.USER)
-                .createdAt(Instant.now())
+                .createdAt(createdAt)
                 .build();
-        TokenResponse tokenResponse = new TokenResponse("jwt-token", "Bearer", 3600L, userId.toString());
 
         when(userEntityRepository.findByEmail("john@test.com")).thenReturn(Optional.empty());
         when(userMapper.toUserEntity(any(RegisterRequest.class))).thenReturn(savedUser);
         when(passwordEncoder.encode("Password1")).thenReturn("encoded");
         when(userEntityRepository.save(any(UserEntity.class))).thenReturn(savedUser);
-        when(jwtService.generateToken("john@test.com", userId.toString(), "john", "USER")).thenReturn(tokenResponse);
 
-        TokenResponse result = authService.createUser(request);
+        RegisterResponse result = authService.createUser(request);
 
         assertNotNull(result);
-        assertEquals("jwt-token", result.token());
+        assertEquals(userId.toString(), result.id());
+        assertEquals("john", result.username());
+        assertEquals("john@test.com", result.email());
+        assertEquals("USER", result.role());
+        assertEquals(createdAt, result.createdAt());
         verify(userEntityRepository).findByEmail("john@test.com");
         verify(userEntityRepository).save(any(UserEntity.class));
+        verify(jwtService, never()).generateToken(any(), any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Descripción
Corrige la respuesta devuelta por `/api/auth/register`. El endpoint devolvía un `accessToken` en lugar del objeto con los datos del usuario.

## Cambios
- Actualizado `AuthController` para devolver el DTO `UserResponse` al registrar

## Respuesta esperada
```json
{
  "id": "550e8400-e29b-41d4-a716-446655440000",
  "username": "javier_ruiz",
  "email": "javier@email.com",
  "role": "USER",
  "createdAt": "2025-01-15T10:30:00Z"
}
```

Closes #6 