### PR TITLE
merge: feature/profiles global constants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # ==================== POLÍTICAS GENERALES ====================
 RESTART_POLICY=unless-stopped
+SPRING_PROFILES_ACTIVE=dev
 
 # ==================== JWT Y SEGURIDAD ====================
 # Ejemplo de clave secreta (usa algo complejo en producción)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
-version: '3.8'
-
 x-common-env: &common-env
   JWT_SECRET: ${JWT_SECRET}
   RAPIDAPI_KEY: ${RAPIDAPI_KEY}
+  SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
 
 x-healthcheck-defaults: &healthcheck-defaults
   interval: 10s
@@ -31,7 +30,7 @@ services:
       resources:
         limits:
           memory: ${REDIS_MEM_LIMIT}
-          cpus: '0.5'
+          cpus: "0.5"
 
   postgres-auth:
     image: postgres:15-alpine
@@ -55,7 +54,7 @@ services:
       resources:
         limits:
           memory: ${AUTH_DB_MEM_LIMIT}
-          cpus: '0.5'
+          cpus: "0.5"
 
   postgres-notifications:
     image: postgres:15-alpine
@@ -79,7 +78,7 @@ services:
       resources:
         limits:
           memory: ${NOTIF_DB_MEM_LIMIT}
-          cpus: '0.5'
+          cpus: "0.5"
 
   ms-auth:
     build: ./ms-auth
@@ -112,7 +111,7 @@ services:
       resources:
         limits:
           memory: ${AUTH_MEM_LIMIT}
-          cpus: '0.5'
+          cpus: "0.5"
 
   ms-leagues:
     build: ./ms-leagues
@@ -130,7 +129,7 @@ services:
       resources:
         limits:
           memory: ${LEAGUES_MEM_LIMIT}
-          cpus: '0.5'
+          cpus: "0.5"
 
   ms-teams:
     build: ./ms-teams
@@ -148,7 +147,7 @@ services:
       resources:
         limits:
           memory: ${TEAMS_MEM_LIMIT}
-          cpus: '0.5'
+          cpus: "0.5"
 
   ms-fixtures:
     build: ./ms-fixtures
@@ -170,7 +169,7 @@ services:
       resources:
         limits:
           memory: ${FIXTURES_MEM_LIMIT}
-          cpus: '0.5'
+          cpus: "0.5"
 
   ms-standings:
     build: ./ms-standings
@@ -192,7 +191,7 @@ services:
       resources:
         limits:
           memory: ${STANDINGS_MEM_LIMIT}
-          cpus: '0.5'
+          cpus: "0.5"
 
   ms-notifications:
     build: ./ms-notifications
@@ -219,7 +218,7 @@ services:
       resources:
         limits:
           memory: ${NOTIF_MEM_LIMIT}
-          cpus: '0.5'
+          cpus: "0.5"
 
   ms-dashboard:
     build: ./ms-dashboard
@@ -247,7 +246,7 @@ services:
       resources:
         limits:
           memory: ${DASHBOARD_MEM_LIMIT}
-          cpus: '0.5'
+          cpus: "0.5"
 
   ms-gateway:
     build: ./ms-gateway
@@ -275,6 +274,7 @@ services:
       redis:
         condition: service_healthy
     environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
       AUTH_SERVICE_URL: ${AUTH_SERVICE_URL}
       LEAGUES_SERVICE_URL: ${LEAGUES_SERVICE_URL}
       TEAMS_SERVICE_URL: ${TEAMS_SERVICE_URL}
@@ -294,7 +294,7 @@ services:
       resources:
         limits:
           memory: ${GATEWAY_MEM_LIMIT}
-          cpus: '1.0'
+          cpus: "1.0"
 
 volumes:
   postgres-auth-data:

--- a/ms-auth/Dockerfile
+++ b/ms-auth/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 COPY src ./src
-RUN mvn clean package -DskipTests -B
+RUN mvn clean package
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/common/constants/ApiPaths.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/common/constants/ApiPaths.java
@@ -1,0 +1,22 @@
+package com.sportpulse.ms_auth.common.constants;
+
+public final class ApiPaths {
+
+    private ApiPaths() {
+    }
+
+    public static final String AUTH_BASE = "/api/auth";
+    public static final String REGISTER = "/register";
+    public static final String LOGIN = "/login";
+    public static final String VALIDATE = "/validate";
+
+    public static final String REGISTER_ENDPOINT = AUTH_BASE + REGISTER;
+    public static final String LOGIN_ENDPOINT = AUTH_BASE + LOGIN;
+    public static final String VALIDATE_ENDPOINT = AUTH_BASE + VALIDATE;
+
+    public static final String[] PUBLIC_AUTH_ENDPOINTS = {
+            REGISTER_ENDPOINT,
+            LOGIN_ENDPOINT,
+            VALIDATE_ENDPOINT
+    };
+}

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/common/constants/ErrorCodes.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/common/constants/ErrorCodes.java
@@ -1,0 +1,14 @@
+package com.sportpulse.ms_auth.common.constants;
+
+public final class ErrorCodes {
+
+    private ErrorCodes() {
+    }
+
+    public static final String INVALID_CREDENTIALS = "INVALID_CREDENTIALS";
+    public static final String ACCESS_DENIED = "ACCESS_DENIED";
+    public static final String USER_ALREADY_EXISTS = "USER_ALREADY_EXISTS";
+    public static final String VALIDATION_ERROR = "VALIDATION_ERROR";
+    public static final String TOKEN_EXPIRED = "TOKEN_EXPIRED";
+    public static final String INVALID_TOKEN = "INVALID_TOKEN";
+}

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/common/constants/ErrorMessages.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/common/constants/ErrorMessages.java
@@ -1,0 +1,13 @@
+package com.sportpulse.ms_auth.common.constants;
+
+public final class ErrorMessages {
+
+    private ErrorMessages() {
+    }
+
+    public static final String INVALID_CREDENTIALS = "Invalid credentials";
+    public static final String USER_ALREADY_EXISTS = "A user with that email already exists";
+    public static final String VALIDATION_FAILED = "Validation failed";
+    public static final String TOKEN_EXPIRED = "The token has expired";
+    public static final String INVALID_TOKEN = "The token is invalid";
+}

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/common/constants/HeaderConstants.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/common/constants/HeaderConstants.java
@@ -1,0 +1,9 @@
+package com.sportpulse.ms_auth.common.constants;
+
+public final class HeaderConstants {
+
+    private HeaderConstants() {
+    }
+
+    public static final String AUTHORIZATION = "Authorization";
+}

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/common/constants/JwtConstants.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/common/constants/JwtConstants.java
@@ -1,0 +1,17 @@
+package com.sportpulse.ms_auth.common.constants;
+
+public final class JwtConstants {
+
+    private JwtConstants() {
+    }
+
+    public static final String TOKEN_TYPE_BEARER = "Bearer";
+    public static final String BEARER_PREFIX = TOKEN_TYPE_BEARER + " ";
+    public static final String ROLE_PREFIX = "ROLE_";
+
+    public static final String CLAIM_USER_ID = "userId";
+    public static final String CLAIM_USERNAME = "username";
+    public static final String CLAIM_ROLE = "role";
+
+    public static final String EXPIRES_IN_SECONDS_DEFAULT = "3600L";
+}

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/common/exception/GlobalExceptionHandler.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.sportpulse.ms_auth.common.exception;
 
+import com.sportpulse.ms_auth.common.constants.ErrorCodes;
+import com.sportpulse.ms_auth.common.constants.ErrorMessages;
 import com.sportpulse.ms_auth.common.model.dto.response.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
@@ -17,25 +19,25 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InvalidCredentialsException.class)
     public ResponseEntity<ErrorResponse> handleInvalidCredentials(
             InvalidCredentialsException ex, HttpServletRequest request) {
-        return buildResponse("INVALID_CREDENTIALS", ex.getMessage(), HttpStatus.UNAUTHORIZED);
+        return buildResponse(ErrorCodes.INVALID_CREDENTIALS, ex.getMessage(), HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(BadCredentialsException.class)
     public ResponseEntity<ErrorResponse> handleBadCredentials(
             BadCredentialsException ex, HttpServletRequest request) {
-        return buildResponse("INVALID_CREDENTIALS", "Invalid credentials", HttpStatus.UNAUTHORIZED);
+        return buildResponse(ErrorCodes.INVALID_CREDENTIALS, ErrorMessages.INVALID_CREDENTIALS, HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDenied(
             AccessDeniedException ex, HttpServletRequest request) {
-        return buildResponse("ACCESS_DENIED", ex.getMessage(), HttpStatus.FORBIDDEN);
+        return buildResponse(ErrorCodes.ACCESS_DENIED, ex.getMessage(), HttpStatus.FORBIDDEN);
     }
 
     @ExceptionHandler(DuplicateEmailException.class)
     public ResponseEntity<ErrorResponse> handleDuplicateEmail(
             DuplicateEmailException ex, HttpServletRequest request) {
-        return buildResponse("USER_ALREADY_EXISTS", "A user with that email already exists", HttpStatus.CONFLICT);
+        return buildResponse(ErrorCodes.USER_ALREADY_EXISTS, ErrorMessages.USER_ALREADY_EXISTS, HttpStatus.CONFLICT);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -44,8 +46,8 @@ public class GlobalExceptionHandler {
         String message = ex.getBindingResult().getFieldErrors().stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .reduce((a, b) -> a + "; " + b)
-                .orElse("Validation failed");
-        return buildResponse("VALIDATION_ERROR", message, HttpStatus.BAD_REQUEST);
+            .orElse(ErrorMessages.VALIDATION_FAILED);
+        return buildResponse(ErrorCodes.VALIDATION_ERROR, message, HttpStatus.BAD_REQUEST);
     }
 
     private ResponseEntity<ErrorResponse> buildResponse(

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/common/model/mapper/UserMapper.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/common/model/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package com.sportpulse.ms_auth.common.model.mapper;
 
+import com.sportpulse.ms_auth.common.constants.JwtConstants;
 import com.sportpulse.ms_auth.common.model.dto.request.RegisterRequest;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenResponse;
 import com.sportpulse.ms_auth.common.model.entities.UserEntity;
@@ -17,8 +18,8 @@ public interface UserMapper {
     UserEntity toUserEntity(RegisterRequest request);
 
     @Mapping(target = "token", source = "token")
-    @Mapping(target = "tokenType", constant = "Bearer")
-    @Mapping(target = "expiresIn", constant = "3600L")
+    @Mapping(target = "tokenType", constant = JwtConstants.TOKEN_TYPE_BEARER)
+    @Mapping(target = "expiresIn", constant = JwtConstants.EXPIRES_IN_SECONDS_DEFAULT)
     @Mapping(target = "userId", ignore = true)
     TokenResponse toTokenResponse(String token);
 }

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/config/JwtAuthFilter.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/config/JwtAuthFilter.java
@@ -1,5 +1,7 @@
 package com.sportpulse.ms_auth.config;
 
+import com.sportpulse.ms_auth.common.constants.HeaderConstants;
+import com.sportpulse.ms_auth.common.constants.JwtConstants;
 import com.sportpulse.ms_auth.service.JwtService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -36,14 +38,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             @NonNull FilterChain filterChain)
             throws ServletException, IOException {
 
-        final String authHeader = request.getHeader("Authorization");
+        final String authHeader = request.getHeader(HeaderConstants.AUTHORIZATION);
 
-        if (!StringUtils.hasText(authHeader) || !authHeader.startsWith("Bearer ")) {
+        if (!StringUtils.hasText(authHeader) || !authHeader.startsWith(JwtConstants.BEARER_PREFIX)) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        final String jwt = authHeader.substring(7);
+        final String jwt = authHeader.substring(JwtConstants.BEARER_PREFIX.length());
         final String userEmail;
 
         try {

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/config/SecurityConfig.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.sportpulse.ms_auth.config;
 
+import com.sportpulse.ms_auth.common.constants.ApiPaths;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,7 +40,7 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**"
                         ).permitAll()
-                        .requestMatchers("/api/auth/register", "/api/auth/login", "/api/auth/validate").permitAll()
+                        .requestMatchers(ApiPaths.PUBLIC_AUTH_ENDPOINTS).permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/controller/AuthApi.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/controller/AuthApi.java
@@ -1,5 +1,6 @@
 package com.sportpulse.ms_auth.controller;
 
+import com.sportpulse.ms_auth.common.constants.ApiPaths;
 import com.sportpulse.ms_auth.common.model.dto.request.LoginRequest;
 import com.sportpulse.ms_auth.common.model.dto.request.RegisterRequest;
 import com.sportpulse.ms_auth.common.model.dto.response.RegisterResponse;
@@ -18,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@RequestMapping("/api/auth")
+@RequestMapping(ApiPaths.AUTH_BASE)
 @Tag(name = "Auth", description = "Authentication and user management operations")
 public interface AuthApi {
 
@@ -34,7 +35,7 @@ public interface AuthApi {
             @ApiResponse(responseCode = "409", description = "Email is already registered",
                     content = @Content(schema = @Schema(implementation = Object.class)))
     })
-    @PostMapping("/register")
+        @PostMapping(ApiPaths.REGISTER)
     ResponseEntity<RegisterResponse> createUser(@Valid @RequestBody RegisterRequest registerRequest);
 
     @Operation(
@@ -49,7 +50,7 @@ public interface AuthApi {
             @ApiResponse(responseCode = "401", description = "Invalid credentials",
                     content = @Content(schema = @Schema(implementation = Object.class)))
     })
-    @PostMapping("/login")
+        @PostMapping(ApiPaths.LOGIN)
     ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest loginRequest);
 
     @Operation(
@@ -65,6 +66,6 @@ public interface AuthApi {
             @ApiResponse(responseCode = "400", description = "Authorization header required and must start with 'Bearer '",
                     content = @Content)
     })
-    @PostMapping("/validate")
+        @PostMapping(ApiPaths.VALIDATE)
     ResponseEntity<TokenPayload> validateToken(@RequestHeader("Authorization") String authHeader);
 }

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/controller/AuthApi.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/controller/AuthApi.java
@@ -1,6 +1,7 @@
 package com.sportpulse.ms_auth.controller;
 
 import com.sportpulse.ms_auth.common.constants.ApiPaths;
+import com.sportpulse.ms_auth.common.constants.HeaderConstants;
 import com.sportpulse.ms_auth.common.model.dto.request.LoginRequest;
 import com.sportpulse.ms_auth.common.model.dto.request.RegisterRequest;
 import com.sportpulse.ms_auth.common.model.dto.response.RegisterResponse;
@@ -67,5 +68,5 @@ public interface AuthApi {
                     content = @Content)
     })
         @PostMapping(ApiPaths.VALIDATE)
-    ResponseEntity<TokenPayload> validateToken(@RequestHeader("Authorization") String authHeader);
+        ResponseEntity<TokenPayload> validateToken(@RequestHeader(HeaderConstants.AUTHORIZATION) String authHeader);
 }

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/controller/impl/AuthApiController.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/controller/impl/AuthApiController.java
@@ -1,5 +1,7 @@
 package com.sportpulse.ms_auth.controller.impl;
 
+import com.sportpulse.ms_auth.common.constants.HeaderConstants;
+import com.sportpulse.ms_auth.common.constants.JwtConstants;
 import com.sportpulse.ms_auth.common.model.dto.request.LoginRequest;
 import com.sportpulse.ms_auth.common.model.dto.request.RegisterRequest;
 import com.sportpulse.ms_auth.common.model.dto.response.RegisterResponse;
@@ -33,8 +35,8 @@ public class AuthApiController implements AuthApi {
     }
 
     @Override
-    public ResponseEntity<TokenPayload> validateToken(@RequestHeader("Authorization") String authHeader) {
-        String token = authHeader.replace("Bearer ", "");
+    public ResponseEntity<TokenPayload> validateToken(@RequestHeader(HeaderConstants.AUTHORIZATION) String authHeader) {
+        String token = authHeader.replace(JwtConstants.BEARER_PREFIX, "");
         TokenPayload payload = authService.validateToken(token);
 
         if (payload.valid()) {

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/service/impl/AuthServiceImpl.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/service/impl/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.sportpulse.ms_auth.service.impl;
 
+import com.sportpulse.ms_auth.common.constants.ErrorCodes;
 import com.sportpulse.ms_auth.common.exception.DuplicateEmailException;
 import com.sportpulse.ms_auth.common.model.dto.request.LoginRequest;
 import com.sportpulse.ms_auth.common.model.dto.request.RegisterRequest;
@@ -40,7 +41,7 @@ public class AuthServiceImpl implements AuthService {
 
         if (userEntityRepository.findByEmail(registerRequest.email()).isPresent()) {
             log.warn("Intento de crear usuario con email existente: {}", registerRequest.email());
-            throw new DuplicateEmailException("USER_ALREADY_EXISTS");
+            throw new DuplicateEmailException(ErrorCodes.USER_ALREADY_EXISTS);
         }
 
         UserEntity userToSave = userMapper.toUserEntity(registerRequest);

--- a/ms-auth/src/main/java/com/sportpulse/ms_auth/service/impl/JwtServiceImpl.java
+++ b/ms-auth/src/main/java/com/sportpulse/ms_auth/service/impl/JwtServiceImpl.java
@@ -1,5 +1,8 @@
 package com.sportpulse.ms_auth.service.impl;
 
+import com.sportpulse.ms_auth.common.constants.ErrorCodes;
+import com.sportpulse.ms_auth.common.constants.ErrorMessages;
+import com.sportpulse.ms_auth.common.constants.JwtConstants;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenPayload;
 import com.sportpulse.ms_auth.common.model.dto.response.TokenResponse;
 import com.sportpulse.ms_auth.service.JwtService;
@@ -38,13 +41,15 @@ public class JwtServiceImpl implements JwtService {
         Date now = new Date();
         Date expirationDate = new Date(now.getTime() + expirationTime);
 
-        String normalizedRole = role.startsWith("ROLE_") ? role.substring(5) : role;
+        String normalizedRole = role.startsWith(JwtConstants.ROLE_PREFIX)
+            ? role.substring(JwtConstants.ROLE_PREFIX.length())
+            : role;
 
         String token = Jwts.builder()
                 .subject(email)
-                .claim("userId", userId)
-                .claim("username", username)
-                .claim("role", normalizedRole)
+            .claim(JwtConstants.CLAIM_USER_ID, userId)
+            .claim(JwtConstants.CLAIM_USERNAME, username)
+            .claim(JwtConstants.CLAIM_ROLE, normalizedRole)
                 .issuedAt(now)
                 .expiration(expirationDate)
                 .signWith(secretKey)
@@ -52,7 +57,7 @@ public class JwtServiceImpl implements JwtService {
 
         return TokenResponse.builder()
             .token(token)
-            .tokenType("Bearer")
+            .tokenType(JwtConstants.TOKEN_TYPE_BEARER)
             .expiresIn(TimeUnit.MILLISECONDS.toSeconds(expirationTime))
             .userId(userId)
                 .build();
@@ -63,25 +68,25 @@ public class JwtServiceImpl implements JwtService {
         try {
             Claims claims = getClaims(token);
             if (claims.getExpiration().before(new Date())) {
-                return new TokenPayload(false, null, null, null, "TOKEN_EXPIRED", "The token has expired");
+                return new TokenPayload(false, null, null, null, ErrorCodes.TOKEN_EXPIRED, ErrorMessages.TOKEN_EXPIRED);
             }
             return new TokenPayload(
                     true,
-                    claims.get("userId", String.class),
-                    claims.get("username", String.class),
-                    claims.get("role", String.class),
+                    claims.get(JwtConstants.CLAIM_USER_ID, String.class),
+                    claims.get(JwtConstants.CLAIM_USERNAME, String.class),
+                    claims.get(JwtConstants.CLAIM_ROLE, String.class),
                     null,
                     null
             );
         } catch (IllegalArgumentException e) {
             if (e.getMessage() != null && e.getMessage().contains("expirado")) {
-                return new TokenPayload(false, null, null, null, "TOKEN_EXPIRED", "The token has expired");
+                return new TokenPayload(false, null, null, null, ErrorCodes.TOKEN_EXPIRED, ErrorMessages.TOKEN_EXPIRED);
             }
             log.warn("Token JWT inválido: {}", e.getMessage());
-            return new TokenPayload(false, null, null, null, "INVALID_TOKEN", "The token is invalid");
+            return new TokenPayload(false, null, null, null, ErrorCodes.INVALID_TOKEN, ErrorMessages.INVALID_TOKEN);
         } catch (Exception e) {
             log.warn("Token JWT inválido: {}", e.getMessage());
-            return new TokenPayload(false, null, null, null, "INVALID_TOKEN", "The token is invalid");
+            return new TokenPayload(false, null, null, null, ErrorCodes.INVALID_TOKEN, ErrorMessages.INVALID_TOKEN);
         }
     }
 
@@ -110,7 +115,7 @@ public class JwtServiceImpl implements JwtService {
 
     @Override
     public String extractRole(String token) {
-        return getClaims(token).get("role", String.class);
+        return getClaims(token).get(JwtConstants.CLAIM_ROLE, String.class);
     }
 
     @Override

--- a/ms-auth/src/main/resources/application-dev.yml
+++ b/ms-auth/src/main/resources/application-dev.yml
@@ -1,0 +1,44 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+server:
+  port: ${SERVER_PORT}
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-expiration: ${JWT_ACCESS_EXPIRATION}
+  refresh-expiration: ${JWT_REFRESH_EXPIRATION}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: always
+  health:
+    db:
+      enabled: true
+    redis:
+      enabled: true
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: true

--- a/ms-auth/src/main/resources/application-prod.yml
+++ b/ms-auth/src/main/resources/application-prod.yml
@@ -1,0 +1,44 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+server:
+  port: ${SERVER_PORT}
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-expiration: ${JWT_ACCESS_EXPIRATION}
+  refresh-expiration: ${JWT_REFRESH_EXPIRATION}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: never
+  health:
+    db:
+      enabled: true
+    redis:
+      enabled: true
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: false

--- a/ms-auth/src/main/resources/application.yaml
+++ b/ms-auth/src/main/resources/application.yaml
@@ -1,49 +1,5 @@
 spring:
   application:
     name: ms-auth
-
-  datasource:
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: org.postgresql.Driver
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-
-server:
-  port: ${SERVER_PORT}
-
-jwt:
-  secret: ${JWT_SECRET}
-  access-expiration: ${JWT_ACCESS_EXPIRATION}
-  refresh-expiration: ${JWT_REFRESH_EXPIRATION}
-
-# ==================== ACTUATOR (Health Check) ====================
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health,info
-  endpoint:
-    health:
-      show-details: always
-  health:
-    db:
-      enabled: true
-    redis:
-      enabled: true
-
-springdoc:
-  swagger-ui:
-    path: /swagger-ui.html
-    enabled: true
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}

--- a/ms-auth/src/test/java/com/sportpulse/ms_auth/MsAuthApplicationTests.java
+++ b/ms-auth/src/test/java/com/sportpulse/ms_auth/MsAuthApplicationTests.java
@@ -2,9 +2,11 @@ package com.sportpulse.ms_auth;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @TestPropertySource(properties = {
     "DB_HOST=localhost",
     "DB_PORT=5432",

--- a/ms-auth/src/test/java/com/sportpulse/ms_auth/controller/AuthApiControllerTest.java
+++ b/ms-auth/src/test/java/com/sportpulse/ms_auth/controller/AuthApiControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 @TestPropertySource(properties = {
     "spring.jpa.hibernate.ddl-auto=create-drop",
     "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"

--- a/ms-auth/src/test/java/com/sportpulse/ms_auth/exception/GlobalExceptionHandlerTest.java
+++ b/ms-auth/src/test/java/com/sportpulse/ms_auth/exception/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package com.sportpulse.ms_auth.exception;
 
+import com.sportpulse.ms_auth.common.constants.ErrorCodes;
 import com.sportpulse.ms_auth.common.exception.AccessDeniedException;
 import com.sportpulse.ms_auth.common.exception.DuplicateEmailException;
 import com.sportpulse.ms_auth.common.exception.GlobalExceptionHandler;
@@ -39,7 +40,7 @@ class GlobalExceptionHandlerTest {
                 new InvalidCredentialsException("Invalid credentials"), request);
 
         assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
-        assertEquals("INVALID_CREDENTIALS", response.getBody().error());
+        assertEquals(ErrorCodes.INVALID_CREDENTIALS, response.getBody().error());
         assertEquals("Invalid credentials", response.getBody().message());
         assertNotNull(response.getBody().timestamp());
         assertTrue(response.getBody().timestamp().toString().endsWith("Z"));
@@ -51,7 +52,7 @@ class GlobalExceptionHandlerTest {
                 new BadCredentialsException("Bad credentials"), request);
 
         assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
-        assertEquals("INVALID_CREDENTIALS", response.getBody().error());
+        assertEquals(ErrorCodes.INVALID_CREDENTIALS, response.getBody().error());
         assertEquals("Invalid credentials", response.getBody().message());
         assertNotNull(response.getBody().timestamp());
     }
@@ -62,7 +63,7 @@ class GlobalExceptionHandlerTest {
                 new AccessDeniedException("Access denied"), request);
 
         assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
-        assertEquals("ACCESS_DENIED", response.getBody().error());
+        assertEquals(ErrorCodes.ACCESS_DENIED, response.getBody().error());
         assertEquals("Access denied", response.getBody().message());
         assertNotNull(response.getBody().timestamp());
     }
@@ -73,7 +74,7 @@ class GlobalExceptionHandlerTest {
                 new DuplicateEmailException("A user with that email already exists"), request);
 
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
-        assertEquals("USER_ALREADY_EXISTS", response.getBody().error());
+        assertEquals(ErrorCodes.USER_ALREADY_EXISTS, response.getBody().error());
         assertEquals("A user with that email already exists", response.getBody().message());
         assertNotNull(response.getBody().timestamp());
     }
@@ -90,7 +91,7 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<ErrorResponse> response = handler.handleValidationErrors(ex, request);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertEquals("VALIDATION_ERROR", response.getBody().error());
+        assertEquals(ErrorCodes.VALIDATION_ERROR, response.getBody().error());
         assertTrue(response.getBody().message().contains("email"));
         assertNotNull(response.getBody().timestamp());
     }

--- a/ms-auth/src/test/resources/application-test.yml
+++ b/ms-auth/src/test/resources/application-test.yml
@@ -7,10 +7,14 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
   h2:
     console:
       enabled: true
@@ -21,3 +25,8 @@ server:
 jwt:
   secret: test-secret-key-for-testing-purposes-minimum-32-chars
   access-expiration: 3600000
+  refresh-expiration: 86400000
+
+springdoc:
+  swagger-ui:
+    enabled: false

--- a/ms-dashboard/Dockerfile
+++ b/ms-dashboard/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 COPY src ./src
-RUN mvn clean package -DskipTests -B
+RUN mvn clean package
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app

--- a/ms-dashboard/src/main/resources/application-dev.yml
+++ b/ms-dashboard/src/main/resources/application-dev.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${SERVER_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always

--- a/ms-dashboard/src/main/resources/application-prod.yml
+++ b/ms-dashboard/src/main/resources/application-prod.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${SERVER_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/ms-dashboard/src/main/resources/application.yaml
+++ b/ms-dashboard/src/main/resources/application.yaml
@@ -1,15 +1,5 @@
 spring:
   application:
     name: ms-dashboard
-
-server:
-  port: ${SERVER_PORT}
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health
-  endpoint:
-    health:
-      show-details: always
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}

--- a/ms-dashboard/src/test/java/com/sportpulse/ms_dashboard/MsDashboardApplicationTests.java
+++ b/ms-dashboard/src/test/java/com/sportpulse/ms_dashboard/MsDashboardApplicationTests.java
@@ -2,8 +2,10 @@ package com.sportpulse.ms_dashboard;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MsDashboardApplicationTests {
 
 	@Test

--- a/ms-dashboard/src/test/resources/application-test.yml
+++ b/ms-dashboard/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+server:
+  port: 0
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/ms-fixtures/Dockerfile
+++ b/ms-fixtures/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 COPY src ./src
-RUN mvn clean package -DskipTests -B
+RUN mvn clean package
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app

--- a/ms-fixtures/src/main/resources/application-dev.yml
+++ b/ms-fixtures/src/main/resources/application-dev.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${SERVER_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always

--- a/ms-fixtures/src/main/resources/application-prod.yml
+++ b/ms-fixtures/src/main/resources/application-prod.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${SERVER_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/ms-fixtures/src/main/resources/application.yaml
+++ b/ms-fixtures/src/main/resources/application.yaml
@@ -1,15 +1,5 @@
 spring:
   application:
     name: ms-fixtures
-
-server:
-  port: ${SERVER_PORT}
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health
-  endpoint:
-    health:
-      show-details: always
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}

--- a/ms-fixtures/src/test/java/com/sportpulse/ms_fixtures/MsFixturesApplicationTests.java
+++ b/ms-fixtures/src/test/java/com/sportpulse/ms_fixtures/MsFixturesApplicationTests.java
@@ -2,8 +2,10 @@ package com.sportpulse.ms_fixtures;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MsFixturesApplicationTests {
 
 	@Test

--- a/ms-fixtures/src/test/resources/application-test.yml
+++ b/ms-fixtures/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+server:
+  port: 0
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/ms-gateway/Dockerfile
+++ b/ms-gateway/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 COPY src ./src
-RUN mvn clean package -DskipTests -B
+RUN mvn clean package
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app

--- a/ms-gateway/src/main/java/com/sportpulse/ms_gateway/config/ApiPathConstants.java
+++ b/ms-gateway/src/main/java/com/sportpulse/ms_gateway/config/ApiPathConstants.java
@@ -1,0 +1,23 @@
+package com.sportpulse.ms_gateway.config;
+
+import java.util.List;
+
+public final class ApiPathConstants {
+
+    private ApiPathConstants() {
+    }
+
+    public static final String AUTH_REGISTER = "/api/auth/register";
+    public static final String AUTH_LOGIN = "/api/auth/login";
+    public static final String AUTH_VALIDATE = "/api/auth/validate";
+
+    public static final List<String> OPEN_API_ENDPOINTS = List.of(
+            AUTH_REGISTER,
+            AUTH_LOGIN,
+            AUTH_VALIDATE,
+            "/v3/api-docs",
+            "/swagger-ui",
+            "/health",
+            "/actuator"
+    );
+}

--- a/ms-gateway/src/main/java/com/sportpulse/ms_gateway/config/RouterValidator.java
+++ b/ms-gateway/src/main/java/com/sportpulse/ms_gateway/config/RouterValidator.java
@@ -3,25 +3,18 @@ package com.sportpulse.ms_gateway.config;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.function.Predicate;
 
 @Component
 public class RouterValidator {
 
-    public static final List<String> openApiEndpoints = List.of(
-            "/api/auth/register",
-            "/api/auth/login",
-            "/api/auth/validate",
-            "/v3/api-docs",
-            "/swagger-ui",
-            "/health",
-            "/actuator"
-    );
-
-    public Predicate<ServerHttpRequest> isSecured =
-            request -> openApiEndpoints
+        private final Predicate<ServerHttpRequest> securedRoutePredicate =
+            request -> ApiPathConstants.OPEN_API_ENDPOINTS
                     .stream()
                     .noneMatch(uri -> request.getURI().getPath().contains(uri));
+
+        public boolean isSecured(ServerHttpRequest request) {
+                return securedRoutePredicate.test(request);
+        }
 
 }

--- a/ms-gateway/src/main/java/com/sportpulse/ms_gateway/constants/GatewayErrorCodes.java
+++ b/ms-gateway/src/main/java/com/sportpulse/ms_gateway/constants/GatewayErrorCodes.java
@@ -1,0 +1,9 @@
+package com.sportpulse.ms_gateway.constants;
+
+public final class GatewayErrorCodes {
+
+    private GatewayErrorCodes() {
+    }
+
+    public static final String SERVICE_UNAVAILABLE = "SERVICE_UNAVAILABLE";
+}

--- a/ms-gateway/src/main/java/com/sportpulse/ms_gateway/constants/GatewayHeaders.java
+++ b/ms-gateway/src/main/java/com/sportpulse/ms_gateway/constants/GatewayHeaders.java
@@ -1,0 +1,12 @@
+package com.sportpulse.ms_gateway.constants;
+
+public final class GatewayHeaders {
+
+    private GatewayHeaders() {
+    }
+
+    public static final String X_USER_ID = "X-User-Id";
+    public static final String X_USER_ROLE = "X-User-Role";
+    public static final String X_USER_NAME = "X-User-Name";
+    public static final String BEARER_PREFIX = "Bearer ";
+}

--- a/ms-gateway/src/main/java/com/sportpulse/ms_gateway/constants/GatewayMessages.java
+++ b/ms-gateway/src/main/java/com/sportpulse/ms_gateway/constants/GatewayMessages.java
@@ -1,0 +1,13 @@
+package com.sportpulse.ms_gateway.constants;
+
+public final class GatewayMessages {
+
+    private GatewayMessages() {
+    }
+
+    public static final String AUTH_HEADER_MISSING = "Authorization header is missing";
+    public static final String TOKEN_FORMAT_INVALID = "Token format is invalid";
+    public static final String INVALID_OR_EXPIRED_TOKEN = "Invalid or expired token";
+    public static final String AUTHENTICATION_ERROR = "Centralized authentication error";
+    public static final String SERVICE_UNAVAILABLE = "Service is currently unavailable. Please try again later.";
+}

--- a/ms-gateway/src/main/java/com/sportpulse/ms_gateway/constants/HealthConstants.java
+++ b/ms-gateway/src/main/java/com/sportpulse/ms_gateway/constants/HealthConstants.java
@@ -1,0 +1,16 @@
+package com.sportpulse.ms_gateway.constants;
+
+public final class HealthConstants {
+
+    private HealthConstants() {
+    }
+
+    public static final String KEY_GATEWAY = "gateway";
+    public static final String KEY_TIMESTAMP = "timestamp";
+    public static final String KEY_SERVICES = "services";
+
+    public static final String STATUS_UP = "UP";
+    public static final String STATUS_DOWN = "DOWN";
+
+    public static final String ACTUATOR_HEALTH_PATH = "/actuator/health";
+}

--- a/ms-gateway/src/main/java/com/sportpulse/ms_gateway/exception/GlobalExceptionHandler.java
+++ b/ms-gateway/src/main/java/com/sportpulse/ms_gateway/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.sportpulse.ms_gateway.exception;
 
 import java.time.Instant;
 
+import com.sportpulse.ms_gateway.constants.GatewayErrorCodes;
+import com.sportpulse.ms_gateway.constants.GatewayMessages;
 import com.sportpulse.ms_gateway.dto.ErrorResponse;
 
 import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
@@ -39,8 +41,8 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
             message = reason != null ? reason : status.getReasonPhrase();
         } else {
             status = HttpStatus.SERVICE_UNAVAILABLE;
-            error = "SERVICE_UNAVAILABLE";
-            message = "Service is currently unavailable. Please try again later.";
+            error = GatewayErrorCodes.SERVICE_UNAVAILABLE;
+            message = GatewayMessages.SERVICE_UNAVAILABLE;
         }
 
         exchange.getResponse().setStatusCode(status);

--- a/ms-gateway/src/main/java/com/sportpulse/ms_gateway/filter/AuthenticationFilter.java
+++ b/ms-gateway/src/main/java/com/sportpulse/ms_gateway/filter/AuthenticationFilter.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.sportpulse.ms_gateway.config.ApiPathConstants;
 import com.sportpulse.ms_gateway.config.RouterValidator;
+import com.sportpulse.ms_gateway.constants.GatewayHeaders;
+import com.sportpulse.ms_gateway.constants.GatewayMessages;
 import com.sportpulse.ms_gateway.dto.ErrorResponse;
 import com.sportpulse.ms_gateway.dto.TokenPayload;
 import org.springframework.beans.factory.annotation.Value;
@@ -53,12 +55,12 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Authentic
                 
                 // 2. Verificar si existe el header Authorization
                 if (!request.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
-                    return onError(exchange, "Authorization header is missing", HttpStatus.UNAUTHORIZED);
+                    return onError(exchange, GatewayMessages.AUTH_HEADER_MISSING, HttpStatus.UNAUTHORIZED);
                 }
 
                 String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
-                if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-                    return onError(exchange, "Token format is invalid", HttpStatus.UNAUTHORIZED);
+                if (authHeader == null || !authHeader.startsWith(GatewayHeaders.BEARER_PREFIX)) {
+                    return onError(exchange, GatewayMessages.TOKEN_FORMAT_INVALID, HttpStatus.UNAUTHORIZED);
                 }
 
                 // 3. Validar token contra el microservicio ms-auth
@@ -72,17 +74,17 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Authentic
                             if (payload != null && payload.isValid()) {
                                 // 4. Enriquecer la request con info del usuario para los MS destino
                                 ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
-                                        .header("X-User-Id", payload.getUserId())
-                                        .header("X-User-Role", payload.getRole())
-                                        .header("X-User-Name", payload.getUsername())
+                                    .header(GatewayHeaders.X_USER_ID, payload.getUserId())
+                                    .header(GatewayHeaders.X_USER_ROLE, payload.getRole())
+                                    .header(GatewayHeaders.X_USER_NAME, payload.getUsername())
                                         .build();
 
                                 return chain.filter(exchange.mutate().request(mutatedRequest).build());
                             } else {
-                                return onError(exchange, "Invalid or expired token", HttpStatus.UNAUTHORIZED);
+                                return onError(exchange, GatewayMessages.INVALID_OR_EXPIRED_TOKEN, HttpStatus.UNAUTHORIZED);
                             }
                         })
-                        .onErrorResume(e -> onError(exchange, "Centralized authentication error", HttpStatus.UNAUTHORIZED));
+                        .onErrorResume(e -> onError(exchange, GatewayMessages.AUTHENTICATION_ERROR, HttpStatus.UNAUTHORIZED));
             }
             
             // Si no es segura (es pública), continuar sin validar

--- a/ms-gateway/src/main/java/com/sportpulse/ms_gateway/filter/AuthenticationFilter.java
+++ b/ms-gateway/src/main/java/com/sportpulse/ms_gateway/filter/AuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.sportpulse.ms_gateway.filter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.sportpulse.ms_gateway.config.ApiPathConstants;
 import com.sportpulse.ms_gateway.config.RouterValidator;
 import com.sportpulse.ms_gateway.dto.ErrorResponse;
 import com.sportpulse.ms_gateway.dto.TokenPayload;
@@ -39,7 +40,8 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Authentic
         this.routerValidator = routerValidator;
     }
 
-    public static class Config {}
+    public static class Config {
+    }
 
     @Override
     public GatewayFilter apply(Config config) {
@@ -47,7 +49,7 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Authentic
             ServerHttpRequest request = exchange.getRequest();
 
             // 1. Verificar si la ruta requiere autenticación
-            if (routerValidator.isSecured.test(request)) {
+            if (routerValidator.isSecured(request)) {
                 
                 // 2. Verificar si existe el header Authorization
                 if (!request.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
@@ -62,7 +64,7 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Authentic
                 // 3. Validar token contra el microservicio ms-auth
                 return webClientBuilder.build()
                         .post()
-                        .uri(authServiceUrl + "/api/auth/validate")
+                    .uri(authServiceUrl + ApiPathConstants.AUTH_VALIDATE)
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .retrieve()
                         .bodyToMono(TokenPayload.class)

--- a/ms-gateway/src/main/java/com/sportpulse/ms_gateway/health/HealthController.java
+++ b/ms-gateway/src/main/java/com/sportpulse/ms_gateway/health/HealthController.java
@@ -1,5 +1,6 @@
 package com.sportpulse.ms_gateway.health;
 
+import com.sportpulse.ms_gateway.constants.HealthConstants;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,8 +41,8 @@ public class HealthController {
             check(dashboardUrl)
         ).map(tuple -> {
             Map<String, Object> response = new HashMap<>();
-            response.put("gateway", "UP");
-            response.put("timestamp", Instant.now());
+            response.put(HealthConstants.KEY_GATEWAY, HealthConstants.STATUS_UP);
+            response.put(HealthConstants.KEY_TIMESTAMP, Instant.now());
 
             Map<String, String> services = new HashMap<>();
             services.put("ms-auth", tuple.getT1());
@@ -52,18 +53,18 @@ public class HealthController {
             services.put("ms-notifications", tuple.getT6());
             services.put("ms-dashboard", tuple.getT7());
 
-            response.put("services", services);
+            response.put(HealthConstants.KEY_SERVICES, services);
             return response;
         });
     }
 
     private Mono<String> check(String url) {
         return webClient.get()
-            .uri(url + "/actuator/health")
+            .uri(url + HealthConstants.ACTUATOR_HEALTH_PATH)
             .retrieve()
             .toBodilessEntity()
-            .map(response -> "UP")
+            .map(response -> HealthConstants.STATUS_UP)
             .timeout(java.time.Duration.ofSeconds(2))
-            .onErrorReturn("DOWN");
+            .onErrorReturn(HealthConstants.STATUS_DOWN);
     }
 }

--- a/ms-gateway/src/main/resources/application-dev.yml
+++ b/ms-gateway/src/main/resources/application-dev.yml
@@ -1,0 +1,4 @@
+management:
+  health:
+    redis:
+      enabled: false

--- a/ms-gateway/src/main/resources/application-prod.yml
+++ b/ms-gateway/src/main/resources/application-prod.yml
@@ -1,0 +1,7 @@
+management:
+  endpoint:
+    health:
+      show-details: never
+  health:
+    redis:
+      enabled: false

--- a/ms-gateway/src/main/resources/application.yaml
+++ b/ms-gateway/src/main/resources/application.yaml
@@ -4,6 +4,8 @@ server:
 spring:
   application:
     name: ms-gateway
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}
   cloud:
     gateway:
       default-filters:
@@ -47,6 +49,3 @@ management:
     web:
       exposure:
         include: health,info,gateway
-  health:
-    redis:
-      enabled: false

--- a/ms-gateway/src/test/java/com/sportpulse/ms_gateway/MsGatewayApplicationTests.java
+++ b/ms-gateway/src/test/java/com/sportpulse/ms_gateway/MsGatewayApplicationTests.java
@@ -3,9 +3,11 @@ package com.sportpulse.ms_gateway;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @TestPropertySource(properties = {
     "SERVER_PORT=8080",
     "AUTH_SERVICE_URL=http://localhost:8081",

--- a/ms-gateway/src/test/java/com/sportpulse/ms_gateway/exception/GlobalExceptionHandlerTest.java
+++ b/ms-gateway/src/test/java/com/sportpulse/ms_gateway/exception/GlobalExceptionHandlerTest.java
@@ -1,5 +1,7 @@
 package com.sportpulse.ms_gateway.exception;
 
+import com.sportpulse.ms_gateway.constants.GatewayErrorCodes;
+import com.sportpulse.ms_gateway.constants.GatewayMessages;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -62,8 +64,8 @@ class GlobalExceptionHandlerTest {
         @SuppressWarnings("unchecked")
         Map<String, Object> response = objectMapper.readValue(body, Map.class);
 
-        assertEquals("SERVICE_UNAVAILABLE", response.get("error"));
-        assertEquals("Service is currently unavailable. Please try again later.", response.get("message"));
+        assertEquals(GatewayErrorCodes.SERVICE_UNAVAILABLE, response.get("error"));
+        assertEquals(GatewayMessages.SERVICE_UNAVAILABLE, response.get("message"));
         assertTrue(response.containsKey(TIMESTAMP));
         assertFalse(response.containsKey("status"));
         assertFalse(response.containsKey("path"));

--- a/ms-gateway/src/test/resources/application-test.yml
+++ b/ms-gateway/src/test/resources/application-test.yml
@@ -1,0 +1,35 @@
+server:
+  port: 0
+
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: auth-service
+          uri: http://localhost:8081
+          predicates:
+            - Path=/api/auth/**
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+AUTH_SERVICE_URL: http://localhost:8081
+LEAGUES_SERVICE_URL: http://localhost:8082
+TEAMS_SERVICE_URL: http://localhost:8083
+FIXTURES_SERVICE_URL: http://localhost:8084
+STANDINGS_SERVICE_URL: http://localhost:8085
+NOTIFICATIONS_SERVICE_URL: http://localhost:8086
+DASHBOARD_SERVICE_URL: http://localhost:8087
+RATE_LIMIT_PER_IP: 60
+JWT_SECRET: test-secret-key-32-characters-minimum
+REDIS_HOST: localhost
+REDIS_PORT: 6379
+
+management:
+  endpoint:
+    health:
+      show-details: never
+  health:
+    redis:
+      enabled: false

--- a/ms-leagues/Dockerfile
+++ b/ms-leagues/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 COPY src ./src
-RUN mvn clean package -DskipTests -B
+RUN mvn clean package
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app

--- a/ms-leagues/src/main/resources/application-dev.yml
+++ b/ms-leagues/src/main/resources/application-dev.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${SERVER_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always

--- a/ms-leagues/src/main/resources/application-prod.yml
+++ b/ms-leagues/src/main/resources/application-prod.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${SERVER_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/ms-leagues/src/main/resources/application.yaml
+++ b/ms-leagues/src/main/resources/application.yaml
@@ -1,15 +1,5 @@
 spring:
   application:
     name: ms-leagues
-
-server:
-  port: ${SERVER_PORT}
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health
-  endpoint:
-    health:
-      show-details: always
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}

--- a/ms-leagues/src/test/java/com/sportpulse/ms_leagues/MsLeaguesApplicationTests.java
+++ b/ms-leagues/src/test/java/com/sportpulse/ms_leagues/MsLeaguesApplicationTests.java
@@ -2,8 +2,10 @@ package com.sportpulse.ms_leagues;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MsLeaguesApplicationTests {
 
 	@Test

--- a/ms-leagues/src/test/resources/application-test.yml
+++ b/ms-leagues/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+server:
+  port: 0
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/ms-notifications/Dockerfile
+++ b/ms-notifications/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 COPY src ./src
-RUN mvn clean package -DskipTests -B
+RUN mvn clean package
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app

--- a/ms-notifications/src/main/resources/application-dev.yml
+++ b/ms-notifications/src/main/resources/application-dev.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${SERVER_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always

--- a/ms-notifications/src/main/resources/application-prod.yml
+++ b/ms-notifications/src/main/resources/application-prod.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${SERVER_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/ms-notifications/src/main/resources/application.yaml
+++ b/ms-notifications/src/main/resources/application.yaml
@@ -1,15 +1,5 @@
 spring:
   application:
     name: ms-notifications
-
-server:
-  port: ${SERVER_PORT}
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health
-  endpoint:
-    health:
-      show-details: always
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}

--- a/ms-notifications/src/test/java/com/sportpulse/ms_notifications/MsNotificationsApplicationTests.java
+++ b/ms-notifications/src/test/java/com/sportpulse/ms_notifications/MsNotificationsApplicationTests.java
@@ -2,8 +2,10 @@ package com.sportpulse.ms_notifications;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MsNotificationsApplicationTests {
 
 	@Test

--- a/ms-notifications/src/test/resources/application-test.yml
+++ b/ms-notifications/src/test/resources/application-test.yml
@@ -1,0 +1,17 @@
+server:
+  port: 0
+
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/ms-standings/Dockerfile
+++ b/ms-standings/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 COPY src ./src
-RUN mvn clean package -DskipTests -B
+RUN mvn clean package
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app

--- a/ms-standings/src/main/resources/application-dev.yml
+++ b/ms-standings/src/main/resources/application-dev.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${SERVER_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always

--- a/ms-standings/src/main/resources/application-prod.yml
+++ b/ms-standings/src/main/resources/application-prod.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${SERVER_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/ms-standings/src/main/resources/application.yaml
+++ b/ms-standings/src/main/resources/application.yaml
@@ -1,15 +1,5 @@
 spring:
   application:
     name: ms-standings
-
-server:
-  port: ${SERVER_PORT}
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health
-  endpoint:
-    health:
-      show-details: always
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}

--- a/ms-standings/src/test/java/com/sportpulse/ms_standings/MsStandingsApplicationTests.java
+++ b/ms-standings/src/test/java/com/sportpulse/ms_standings/MsStandingsApplicationTests.java
@@ -2,8 +2,10 @@ package com.sportpulse.ms_standings;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MsStandingsApplicationTests {
 
 	@Test

--- a/ms-standings/src/test/resources/application-test.yml
+++ b/ms-standings/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+server:
+  port: 0
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/ms-teams/Dockerfile
+++ b/ms-teams/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 COPY src ./src
-RUN mvn clean package -DskipTests -B
+RUN mvn clean package
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/constants/ApiPaths.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/constants/ApiPaths.java
@@ -1,0 +1,9 @@
+package com.sportpulse.ms_teams.constants;
+
+public final class ApiPaths {
+
+    private ApiPaths() {
+    }
+
+    public static final String TEAMS_BASE = "/api/teams";
+}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/constants/ErrorCodes.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/constants/ErrorCodes.java
@@ -1,0 +1,11 @@
+package com.sportpulse.ms_teams.constants;
+
+public final class ErrorCodes {
+
+    private ErrorCodes() {
+    }
+
+    public static final String MISSING_PARAMETER = "MISSING_PARAMETER";
+    public static final String TEAM_NOT_FOUND = "TEAM_NOT_FOUND";
+    public static final String ERROR = "ERROR";
+}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/constants/ErrorMessages.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/constants/ErrorMessages.java
@@ -1,0 +1,11 @@
+package com.sportpulse.ms_teams.constants;
+
+public final class ErrorMessages {
+
+    private ErrorMessages() {
+    }
+
+    public static final String MISSING_AUTH_USER_CONTEXT = "Missing authenticated user context";
+    public static final String REQUIRED_PARAM_PREFIX = "The parameter '";
+    public static final String REQUIRED_PARAM_SUFFIX = "' is required";
+}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/constants/HeaderConstants.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/constants/HeaderConstants.java
@@ -1,0 +1,9 @@
+package com.sportpulse.ms_teams.constants;
+
+public final class HeaderConstants {
+
+    private HeaderConstants() {
+    }
+
+    public static final String X_USER_ID = "X-User-Id";
+}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/constants/ResponseFields.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/constants/ResponseFields.java
@@ -1,0 +1,11 @@
+package com.sportpulse.ms_teams.constants;
+
+public final class ResponseFields {
+
+    private ResponseFields() {
+    }
+
+    public static final String ERROR = "error";
+    public static final String MESSAGE = "message";
+    public static final String TIMESTAMP = "timestamp";
+}

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/controller/TeamsController.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/controller/TeamsController.java
@@ -1,6 +1,10 @@
 package com.sportpulse.ms_teams.controller;
 
 import java.util.List;
+import com.sportpulse.ms_teams.constants.ApiPaths;
+import com.sportpulse.ms_teams.constants.ErrorCodes;
+import com.sportpulse.ms_teams.constants.ErrorMessages;
+import com.sportpulse.ms_teams.constants.HeaderConstants;
 import com.sportpulse.ms_teams.dto.TeamResponse;
 import com.sportpulse.ms_teams.mapper.TeamMapper;
 import com.sportpulse.ms_teams.service.TeamService;
@@ -22,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 @RestController
-@RequestMapping("/api/teams")
+@RequestMapping(ApiPaths.TEAMS_BASE)
 @Tag(name = "Teams", description = "Team query operations")
 public class TeamsController {
 
@@ -50,7 +54,7 @@ public class TeamsController {
     public ResponseEntity<List<TeamResponse>> getTeamsByLeagueAndSeason(
         @RequestParam int league,
         @RequestParam int season,
-        @RequestHeader(value = "X-User-Id", required = false) String userId
+        @RequestHeader(value = HeaderConstants.X_USER_ID, required = false) String userId
     ) {
         requireUser(userId);
         List<TeamResponse> body = teamService.getTeamsByLeagueAndSeason(league, season)
@@ -75,17 +79,17 @@ public class TeamsController {
     @GetMapping("/{teamId}")
     public ResponseEntity<TeamResponse> getTeamById(
         @PathVariable long teamId,
-        @RequestHeader(value = "X-User-Id", required = false) String userId
+        @RequestHeader(value = HeaderConstants.X_USER_ID, required = false) String userId
     ) {
         requireUser(userId);
         var team = teamService.getTeamById(teamId);
         if (team == null)
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "TEAM_NOT_FOUND");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ErrorCodes.TEAM_NOT_FOUND);
         return ResponseEntity.ok(teamMapper.toResponse(team));
     }
 
     private void requireUser(String userId) {
         if (userId == null || userId.isBlank())
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing authenticated user context");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ErrorMessages.MISSING_AUTH_USER_CONTEXT);
     }
 }

--- a/ms-teams/src/main/java/com/sportpulse/ms_teams/exception/GlobalExceptionHandler.java
+++ b/ms-teams/src/main/java/com/sportpulse/ms_teams/exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.sportpulse.ms_teams.exception;
 
+import com.sportpulse.ms_teams.constants.ErrorCodes;
+import com.sportpulse.ms_teams.constants.ErrorMessages;
+import com.sportpulse.ms_teams.constants.ResponseFields;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -15,9 +18,9 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, Object>> handleMissingParam(
             MissingServletRequestParameterException ex) {
         return ResponseEntity.badRequest().body(Map.of(
-            "error",     "MISSING_PARAMETER",
-            "message",   "The parameter '" + ex.getParameterName() + "' is required",
-            "timestamp", Instant.now().toString()
+            ResponseFields.ERROR, ErrorCodes.MISSING_PARAMETER,
+            ResponseFields.MESSAGE, ErrorMessages.REQUIRED_PARAM_PREFIX + ex.getParameterName() + ErrorMessages.REQUIRED_PARAM_SUFFIX,
+            ResponseFields.TIMESTAMP, Instant.now().toString()
         ));
     }
 
@@ -25,9 +28,9 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, Object>> handleResponseStatus(
             ResponseStatusException ex) {
         return ResponseEntity.status(ex.getStatusCode()).body(Map.of(
-            "error",     ex.getReason() != null ? ex.getReason() : "ERROR",
-            "message",   ex.getMessage(),
-            "timestamp", Instant.now().toString()
+            ResponseFields.ERROR, ex.getReason() != null ? ex.getReason() : ErrorCodes.ERROR,
+            ResponseFields.MESSAGE, ex.getMessage(),
+            ResponseFields.TIMESTAMP, Instant.now().toString()
         ));
     }
 }

--- a/ms-teams/src/main/resources/application-dev.yml
+++ b/ms-teams/src/main/resources/application-dev.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${SERVER_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always

--- a/ms-teams/src/main/resources/application-prod.yml
+++ b/ms-teams/src/main/resources/application-prod.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${SERVER_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/ms-teams/src/main/resources/application.yaml
+++ b/ms-teams/src/main/resources/application.yaml
@@ -1,20 +1,10 @@
 spring:
   application:
     name: ms-teams
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}
 
 api-football:
   base-url: ${API_FOOTBALL_BASE_URL:https://v3.football.api-sports.io}
   host: ${API_FOOTBALL_HOST:v3.football.api-sports.io}
   key: ${RAPIDAPI_KEY}
-
-server:
-  port: ${SERVER_PORT}
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health
-  endpoint:
-    health:
-      show-details: always

--- a/ms-teams/src/test/java/com/sportpulse/ms_teams/MsTeamsApplicationTests.java
+++ b/ms-teams/src/test/java/com/sportpulse/ms_teams/MsTeamsApplicationTests.java
@@ -2,8 +2,10 @@ package com.sportpulse.ms_teams;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MsTeamsApplicationTests {
 
 	@Test

--- a/ms-teams/src/test/java/com/sportpulse/ms_teams/controller/TestControllerTest.java
+++ b/ms-teams/src/test/java/com/sportpulse/ms_teams/controller/TestControllerTest.java
@@ -1,6 +1,8 @@
 package com.sportpulse.ms_teams.exception;
 
 import com.sportpulse.ms_teams.controller.TeamsController;
+import com.sportpulse.ms_teams.constants.ErrorCodes;
+import com.sportpulse.ms_teams.constants.HeaderConstants;
 import com.sportpulse.ms_teams.dto.TeamResponse;
 import com.sportpulse.ms_teams.mapper.TeamMapper;
 import com.sportpulse.ms_teams.model.Team;
@@ -34,9 +36,9 @@ class TeamsControllerTest {
     void whenLeagueMissing_thenReturns400() throws Exception {
         mockMvc.perform(get("/api/teams")
                 .param("season", "2024")
-                .header("X-User-Id", "test-user"))
+                .header(HeaderConstants.X_USER_ID, "test-user"))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").value("MISSING_PARAMETER"));
+            .andExpect(jsonPath("$.error").value(ErrorCodes.MISSING_PARAMETER));
     }
 
     @Test
@@ -52,9 +54,9 @@ class TeamsControllerTest {
         when(teamService.getTeamById(999L)).thenReturn(null);
 
         mockMvc.perform(get("/api/teams/999")
-                .header("X-User-Id", "test-user"))
+                .header(HeaderConstants.X_USER_ID, "test-user"))
             .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.error").value("TEAM_NOT_FOUND"));
+            .andExpect(jsonPath("$.error").value(ErrorCodes.TEAM_NOT_FOUND));
     }
 
     @Test
@@ -68,7 +70,7 @@ class TeamsControllerTest {
         mockMvc.perform(get("/api/teams")
                 .param("league", "140")
                 .param("season", "2024")
-                .header("X-User-Id", "test-user"))
+            .header(HeaderConstants.X_USER_ID, "test-user"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$[0].name").value("FC Barcelona"));
     }

--- a/ms-teams/src/test/java/com/sportpulse/ms_teams/controller/TestControllerTest.java
+++ b/ms-teams/src/test/java/com/sportpulse/ms_teams/controller/TestControllerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 import static org.mockito.Mockito.when;
@@ -17,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TeamsController.class)
+@ActiveProfiles("test")
 class TeamsControllerTest {
 
     @Autowired

--- a/ms-teams/src/test/java/com/sportpulse/ms_teams/exception/GlobalExceptionHandlerTest.java
+++ b/ms-teams/src/test/java/com/sportpulse/ms_teams/exception/GlobalExceptionHandlerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -13,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TeamsController.class)
+@ActiveProfiles("test")
 class GlobalExceptionHandlerTest {
 
     @Autowired

--- a/ms-teams/src/test/java/com/sportpulse/ms_teams/exception/GlobalExceptionHandlerTest.java
+++ b/ms-teams/src/test/java/com/sportpulse/ms_teams/exception/GlobalExceptionHandlerTest.java
@@ -1,5 +1,9 @@
 package com.sportpulse.ms_teams.exception;
+
 import com.sportpulse.ms_teams.controller.TeamsController;
+import com.sportpulse.ms_teams.constants.ErrorCodes;
+import com.sportpulse.ms_teams.constants.HeaderConstants;
+import com.sportpulse.ms_teams.constants.ResponseFields;
 import com.sportpulse.ms_teams.mapper.TeamMapper;
 import com.sportpulse.ms_teams.service.TeamService;
 import org.junit.jupiter.api.Test;
@@ -30,11 +34,11 @@ class GlobalExceptionHandlerTest {
     void whenLeagueMissing_thenReturns400() throws Exception {
         mockMvc.perform(get("/api/teams")
                 .param("season", "2024")
-                .header("X-User-Id", "test-user"))
+                .header(HeaderConstants.X_USER_ID, "test-user"))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").value("MISSING_PARAMETER"))
-            .andExpect(jsonPath("$.message").exists())
-            .andExpect(jsonPath("$.timestamp").exists());
+            .andExpect(jsonPath("$.error").value(ErrorCodes.MISSING_PARAMETER))
+            .andExpect(jsonPath("$." + ResponseFields.MESSAGE).exists())
+            .andExpect(jsonPath("$." + ResponseFields.TIMESTAMP).exists());
     }
 
     @Test
@@ -42,8 +46,8 @@ class GlobalExceptionHandlerTest {
         when(teamService.getTeamById(999L)).thenReturn(null);
 
         mockMvc.perform(get("/api/teams/999")
-                .header("X-User-Id", "test-user"))
+                .header(HeaderConstants.X_USER_ID, "test-user"))
             .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.error").value("TEAM_NOT_FOUND"));
+            .andExpect(jsonPath("$.error").value(ErrorCodes.TEAM_NOT_FOUND));
     }
 }

--- a/ms-teams/src/test/resources/application-test.yml
+++ b/ms-teams/src/test/resources/application-test.yml
@@ -1,0 +1,16 @@
+server:
+  port: 0
+
+api-football:
+  base-url: https://v3.football.api-sports.io
+  host: v3.football.api-sports.io
+  key: test-rapidapi-key
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never


### PR DESCRIPTION
## Descripcion

**1. chore(docker):**
> Se elimina el campo `version` del docker-compose por estar deprecado en versiones modernas de Docker Compose, y se añade la variable de entorno `SPRING_PROFILES_ACTIVE` con valor por defecto `dev`.

**2. chore(config):**
> Se añaden ficheros de configuración específicos por perfil (`application-dev.yml`, `application-prod.yml`, `application-test.yml`) en todos los microservicios para soportar entornos diferenciados.

**3. refactor(common):**
> Se centralizan los literales mágicos (headers, errores, claims, mensajes y claves de respuesta) en clases de constantes por microservicio (`ms-auth`, `ms-gateway`, `ms-teams`), eliminando duplicación en código fuente y tests.